### PR TITLE
Fix refreshdata: New INSPQ data and data processing

### DIFF
--- a/app/refreshdata.py
+++ b/app/refreshdata.py
@@ -46,12 +46,12 @@ def get_month_fr():
 
 # Data sources mapping
 # {filename: url}
-SOURCES = { 
+SOURCES = {
     # Montreal
     # HTML
     'data_mtl.html':
     'https://santemontreal.qc.ca/en/public/coronavirus-covid-19/situation-of-the-coronavirus-covid-19-in-montreal',
-    # CSV (Note: ";" separated)
+    # CSV (Note: ";" separated; Encoding: windows-1252/cp1252)
     'data_mtl_ciuss.csv':
     'https://santemontreal.qc.ca/fileadmin/fichiers/Campagnes/coronavirus/situation-montreal/ciusss.csv',
     'data_mtl_municipal.csv':
@@ -67,12 +67,15 @@ SOURCES = {
     # INSPQ
     # HTML
     'INSPQ_main.html': 'https://www.inspq.qc.ca/covid-19/donnees',
-    'INSPQ_region.html': 'https://www.inspq.qc.ca/covid-19/donnees/details',
-    # CSV (Note: "," separated)
-    'data_qc.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/combine.csv',
-    'data_qc_cases_by_network.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/tableau-rls.csv',
-    'data_qc_death_loc_by_region.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/tableau-rpa.csv'
-    }
+    'INSPQ_region.html': 'https://www.inspq.qc.ca/covid-19/donnees/regions',
+    'INSPQ_par_region.html': 'https://www.inspq.qc.ca/covid-19/donnees/par-region',
+    # CSV (Note: "," separated; Encoding: UTF-8)
+    'data_qc.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/covid19-hist.csv',
+    'data_qc_regions.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/regions.csv',
+    'data_qc_manual.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/manual-data.csv',
+    'data_qc_cases_by_network.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/tableau-rls-new.csv',
+    'data_qc_death_loc_by_region.csv': 'https://www.inspq.qc.ca/sites/default/files/covid/donnees/tableau-rpa-new.csv'
+}
 
 
 # def lock(lock_dir):

--- a/app/refreshdata.py
+++ b/app/refreshdata.py
@@ -536,13 +536,19 @@ def append_mtl_death_loc_csv(sources_dir, processed_dir, date):
     mtl_death_loc_df = pd.read_csv(mtl_death_loc_csv, encoding='utf-8')
     
     mtl_day_df = day_df[day_df['RSS'].str.contains('Montr', na=False)]
-    mtl_day_list = mtl_day_df.iloc[0, 1:9].astype(int).to_list()  # CH, CHSLD, Domicile, RI, RPA, Autre, Inconnu, Décès (n)
-    
-    if not date in mtl_death_loc_df['date']:
+    # CH, CHSLD, Domicile, RI, RPA, Autre, Décès (n)
+    # drop the last column (Deces (%))
+    mtl_day_list = mtl_day_df.iloc[0, 1:8].astype(int).to_list()
+
+    if date not in mtl_death_loc_df['date']:
         mtl_day_list.insert(0, date)
+        # add placeholder for (removed) Inccnnue column
+        # required since target df has this column
+        mtl_day_list.insert(7, 0)
+
         mtl_death_loc_df.loc[mtl_death_loc_df.index.max() + 1, :] = mtl_day_list
 
-        # Overwrite cases_per1000.csv
+        # Overwrite data_mtl_death_loc.csv
         mtl_death_loc_df.to_csv(mtl_death_loc_csv, encoding='utf-8', index=False)
     else:
         print(f'{date} has already been appended to {mtl_death_loc_csv}')


### PR DESCRIPTION
* updates the INSPQ sources to the latest data
* found a fix for the encoding issues still present (try UTF-8, if it fails fall back to cp1252 (this is used in Sante Montreal data))
* updates processing of `data_qc.csv`: re-establishes current currently being used, filters out QC total rows and filters out "Date Inconnue" rows at the beginning
* updates processing of `data_mtl.csv`: switches column index, handles already existing data (replaced with `na`)
* updates processing of MTL death loc CSV: adjusts to change in data format (column `Inconnue` removed)

See #28 and #30.