### PR TITLE
Improve mtl age fig

### DIFF
--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -296,6 +296,10 @@ li {
     grid-template-columns: 1fr;
     row-gap: 15px;
   }
+  .grid-container-two-cols {
+    grid-template-columns: 1fr;
+    row-gap: 15px;
+  }
   #title-container {
     clear: both;
     float: none;
@@ -337,10 +341,6 @@ li {
 }
 
 @media (max-width: 600px) {
-  .grid-container-two-cols {
-    grid-template-columns: 1fr;
-    row-gap: 15px;
-  }
   #title-container {
     clear: both;
     float: none;

--- a/app/core.py
+++ b/app/core.py
@@ -203,6 +203,8 @@ mtl_age = data_mtl_by_age[[
     'cases_mtl_30-39', 'cases_mtl_40-49', 'cases_mtl_50-59',
     'cases_mtl_60-69', 'cases_mtl_70-79', 'cases_mtl_80+'
 ]]
+# clean columns
+mtl_age.columns = mtl_age.columns.str.split('_').str[-1]
 # determine daily new cases and its 7-day rolling avg
 mtl_age = mtl_age.diff().dropna()
 mtl_age = mtl_age.rolling(7).mean().dropna().round()
@@ -220,5 +222,3 @@ mtl_age_data.index = mtl_age_data.index.strftime('%Y-%m-%d')
 # limit data to last 12 weeks
 mtl_age_data = mtl_age_data.iloc[-16:]
 mtl_age_data = mtl_age_data.reset_index().melt(id_vars=['date'], var_name='age', value_name='new_cases')
-# clean up age
-mtl_age_data['age'] = mtl_age_data['age'].str.split('_').str[-1]

--- a/app/figures.py
+++ b/app/figures.py
@@ -281,6 +281,67 @@ def cases_fig(data_mtl, data_qc, labels):
     return cases_fig
 
 
+def mtl_age_fig(mtl_age_data, labels):
+    figure = px.line(
+        mtl_age_data,
+        x='date',
+        y='new_cases',
+        color='age',
+        # split into subplots
+        # facet_col='age',
+        # facet_col_wrap=5,
+        hover_name='age',
+        hover_data={
+            'date': False,
+            'age': True,
+        },
+    )
+
+    figure.update_layout({
+        'autosize': True,
+        'showlegend': True,
+        'legend_title_text': '',
+        'legend': {
+            'bgcolor': 'rgba(255,255,255,0)',
+            'x': 0,
+            'y': 1.03,
+            'xanchor': 'left',
+            'orientation': 'h',
+            'font': {'size': 11}
+        },
+        'xaxis': {
+            # 'tickformat': '%m-%d\n%Y',
+            'tickformat': '%V\n%b %Y',
+            'title': {'text': labels['week_label']},
+            'hoverformat': 'Week %V (of %Y-%m-%d)',
+            'ticks': 'inside',
+            'dtick': 7 * 86400000.0,
+            'tick0': mtl_age_data['date'][0],
+            'tickcolor': '#ccc',
+        },
+        'yaxis': {
+            'title': {'text': '%'},
+            'gridcolor': COLOUR_GRID,
+            'rangemode': 'tozero',
+            'constrain': 'domain',
+            'ticksuffix': '%',
+        },
+        'margin': {'r': 0, 't': 30, 'l': 60, 'b': 30},
+        'plot_bgcolor': 'rgba(255,255,255,1)',
+        'paper_bgcolor': 'rgba(255,255,255,1)',
+        'hovermode': 'x unified',
+        'dragmode': False,
+    })
+
+    figure.update_traces({
+        'mode': 'lines+markers',
+        # 'line_shape': 'spline',
+        'hovertemplate': '%{y}',
+    })
+
+    return figure
+
+
 def mtl_age_hist_fig(mtl_age_data, labels):
     # Age histogram
     mtl_age_data_copy = mtl_age_data.copy()

--- a/app/languages/app_en.py
+++ b/app/languages/app_en.py
@@ -35,7 +35,7 @@ labels = {
     'negative_tests_qc_box_label': 'Negative tests (QC)',
     'montreal_map_label': 'Cases per 100,000 population (Island of Montreal)',
     'total_cases_label': 'Confirmed cases',
-    'age_group_label': 'Cases by age group (MTL)',
+    'age_group_label': 'Distribution of new cases across all age groups by week (MTL)',
     'total_deaths_label': 'Deaths (QC)',
     'total_hospitalisations_label': 'Hospitalisations (QC)',
     'intensive_care_label': 'Intensive Care (QC)',
@@ -75,6 +75,7 @@ labels = {
     'active_cases_qc_label': 'Active cases (QC)',
     'new_cases_qc_label': 'New cases (QC)',
     'new_cases_mtl_label': 'New cases (MTL)',
+    # age groups
     'age_total_label': 'Distribution of total<br>cases across age groups',
     'age_per100000_label': 'Distribution of cases per<br>100,000 population in age group',
     'age_fig_hovertemplate': '%: %{y}',
@@ -106,6 +107,7 @@ labels = {
     'date_slider_label': 'Date: ',
     'date_label': 'Date',
     'age_label': 'Age',
+    'week_label': 'Week',
     'linear_label': 'Linear scale',
     'log_label': 'Log scale',
     # Confirmed deaths by place of residence (MTL) fig

--- a/app/languages/app_es.py
+++ b/app/languages/app_es.py
@@ -35,7 +35,7 @@ labels = {
     'negative_tests_qc_box_label': 'Pruebas negativas (QC)',
     'montreal_map_label': 'Casos por cada 100 000 habitantes (Isla de Montreal)',
     'total_cases_label': 'Casos confirmados',
-    'age_group_label': 'Casos por grupo de edad (MTL)',
+    'age_group_label': 'Distribution of new cases across all age groups by week (MTL)',
     'total_deaths_label': 'Muertes (QC)',
     'total_hospitalisations_label': 'Hospitalizaciones (QC)',
     'intensive_care_label': 'Cuidados intensivos (QC)',
@@ -75,6 +75,7 @@ labels = {
     'active_cases_qc_label': 'Casos activos (QC)',
     'new_cases_qc_label': 'Casos nuevos (QC)',
     'new_cases_mtl_label': 'Casos nuevos (MTL)',
+    # age groups
     'age_total_label': 'Distribución del total<br>de casos en el grupo de edad',
     'age_per100000_label': 'Distribución de casos por cada<br>100,000 habitantes en el grupo de edad',
     'age_fig_hovertemplate': '%: %{y}',
@@ -106,6 +107,7 @@ labels = {
     'date_slider_label': 'Fecha: ',
     'date_label': 'Fecha',
     'age_label': 'Edad',
+    'week_label': 'Week',
     'linear_label': 'Escala lineal',
     'log_label': 'Escala logarítmica',
     # Confirmed deaths by place of residence (MTL) fig

--- a/app/languages/app_fr.py
+++ b/app/languages/app_fr.py
@@ -35,7 +35,7 @@ labels = {
     'negative_tests_qc_box_label': 'Analyses négatives (QC)',
     'montreal_map_label': 'Cas pour 100 000 habitants (Île de Montréal)',
     'total_cases_label': 'Cas confirmés',
-    'age_group_label': "Cas confirmés selon le groupe d'âge (MTL)",
+    'age_group_label': "Répartition des nouveaux cas parmi les groupes d'âge par semaine (MTL)",
     'total_deaths_label': 'Décès (QC)',
     'total_hospitalisations_label': 'Hospitalisations (QC)',
     'intensive_care_label': 'Soins Intensifs (QC)',
@@ -75,6 +75,7 @@ labels = {
     'active_cases_qc_label': 'Cas actif (QC)',
     'new_cases_qc_label': 'Nouveaux cas (QC)',
     'new_cases_mtl_label': 'Nouveaux cas (MTL)',
+    # age groups
     'age_total_label': "Répartition des cas<br>parmi les groupes d'âge",
     'age_per100000_label': "Répartition des cas par 100 000<br>habitants dans chaque groupe d'âge",
     'age_fig_hovertemplate': '%: %{y}',
@@ -106,6 +107,7 @@ labels = {
     'date_slider_label': 'Date: ',
     'date_label': 'Date',
     'age_label': 'Age',
+    'week_label': 'Semaine',
     'linear_label': 'Échelle linéaire',
     'log_label': 'Échelle logarithmique',
     # Confirmed deaths by place of residence (MTL) fig

--- a/app/languages/app_zh.py
+++ b/app/languages/app_zh.py
@@ -35,7 +35,7 @@ labels = {
     'negative_tests_qc_box_label': '检测阴性（魁省）',
     'montreal_map_label': '病例／100 000人（蒙特利尔岛）',
     'total_cases_label': '确诊病例',
-    'age_group_label': '不同年龄组确诊病例（蒙特利尔）',
+    'age_group_label': 'Distribution of new cases across all age groups by week (MTL)',
     'total_deaths_label': '死亡（魁省）',
     'total_hospitalisations_label': '入院人数（魁省）',
     'intensive_care_label': '重症患者 （魁省）',
@@ -75,6 +75,7 @@ labels = {
     'active_cases_qc_label': 'Active cases (QC)',
     'new_cases_qc_label': 'New cases (QC)',
     'new_cases_mtl_label': 'New cases (MTL)',
+    # age groups
     'age_total_label': '各年龄组总病例分布情况',
     'age_per100000_label': '每10万人口不同年龄组病例分布情况',
     'age_fig_hovertemplate': '%: %{y}',
@@ -106,6 +107,7 @@ labels = {
     'date_slider_label': '日期: ',
     'date_label': '日期',
     'age_label': '年龄',
+    'week_label': 'Week',
     'linear_label': '线性尺度',
     'log_label': '对数尺度',
     # Confirmed deaths by place of residence (MTL) fig

--- a/app/template.py
+++ b/app/template.py
@@ -16,7 +16,7 @@ def generate_layout(labels):
     # Figures #####
     mtlmap_fig = figures.mtl_cases_map_fig(mtl_boroughs, mtl_geojson, labels)
     cases_fig = figures.cases_fig(data_mtl, data_qc, labels)
-    age_fig = figures.mtl_age_hist_fig(mtl_age_data, labels)
+    age_fig = figures.mtl_age_fig(mtl_age_data, labels)
     deaths_fig = figures.deaths_fig(data_mtl, data_qc, labels)
     hospitalisations_fig = figures.hospitalisations_fig(data_qc_hosp, data_qc, data_mtl, labels)
     testing_fig = figures.testing_fig(data_qc, data_mtl, labels)


### PR DESCRIPTION
Changes the MTL age figure to show 7-day avg of cases per calendar week with the last 16 weeks.

The reason it is limited to the last 16 weeks is due to the y-axis range being quite large due to high cases in the summer in the 20-29 age group. Unfortunately, the y-axis does not automatically update its range when a smaller range is shown. To do this a callback would be required to update manually, see here for example: https://stackoverflow.com/questions/62166896/plotly-dash-stock-app-in-python-with-clientside-callback-yaxis-autoscale-on-xa

<img width="594" alt="Screen Shot 2021-03-10 at 22 09 41" src="https://user-images.githubusercontent.com/9328433/110729821-5c421900-81ed-11eb-9df4-366e3dfe5a72.png">

The hover is `x unified` to keep the ordering of age groups. It would also be possible to add some additional data, such as 7-day rolling avg or 7-day incidence but I left it for now since it requires more work to build the df, resample it, and bring it from wide to long format.

Instead of throwing everything in one, [facet plots](https://plotly.com/python/facet-plots/) could be used to have sub-plots by age group:
<img width="1337" alt="Screen Shot 2021-02-27 at 14 25 31" src="https://user-images.githubusercontent.com/9328433/110729554-eccc2980-81ec-11eb-9634-58192da93c04.png">
